### PR TITLE
Migrated to react-aria-components library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "electron-squirrel-startup": "^1.0.1",
         "lucide-react": "^0.511.0",
         "react": "^19.1.0",
+        "react-aria-components": "^1.11.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
@@ -1758,6 +1759,57 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -1837,6 +1889,43 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.2.tgz",
+      "integrity": "sha512-/wENk7CbvLbkUvX1tu0mwq49CVkkWpkXubGel6birjRPyo6uQ4nQpnq5xZu823zRCwwn82zgHrvgF1vZyvmVgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.8.tgz",
+      "integrity": "sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.4.tgz",
+      "integrity": "sha512-P+/h+RDaiX8EGt3shB9AYM1+QgkvHmJ5rKi4/59k4sg9g58k9rqsRW0WxRO7jCoHyvVbFRRFKmVTdFYdehrxHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.7.tgz",
+      "integrity": "sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -2166,15 +2255,282 @@
         "node": ">=14"
       }
     },
-    "node_modules/@react-aria/focus": {
-      "version": "3.20.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.3.tgz",
-      "integrity": "sha512-rR5uZUMSY4xLHmpK/I8bP1V6vUNHFo33gTvrvNUsAKKqvMfa7R2nu5A6v97dr5g6tVH6xzpdkPsOJCWh90H2cw==",
+    "node_modules/@react-aria/autocomplete": {
+      "version": "3.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-beta.6.tgz",
+      "integrity": "sha512-/i0Y1nJNSDk5k49tlApYfFCylZO597KQSMy4AbG60W6VNUw51QrmY9bzO3zdGAEVdPSuMys/72KwvV6LOpllyQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/interactions": "^3.25.1",
-        "@react-aria/utils": "^3.29.0",
-        "@react-types/shared": "^3.29.1",
+        "@react-aria/combobox": "^3.13.0",
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/listbox": "^3.14.7",
+        "@react-aria/searchfield": "^3.8.7",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/autocomplete": "3.0.0-beta.3",
+        "@react-stately/combobox": "^3.11.0",
+        "@react-types/autocomplete": "3.0.0-alpha.33",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.27.tgz",
+      "integrity": "sha512-fuXD9nvBaBVZO0Z6EntBlxQD621/2Ldcxz76jFjc4V/jNOq/6BIVQRtpnAYYrSTiW3ZV2IoAyxRWNxQU22hOow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/link": "^3.8.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/breadcrumbs": "^3.7.15",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.14.0.tgz",
+      "integrity": "sha512-we6z+2GpZO8lGD6EPmYH2S87kLCpU14D2E3tD2vES+SS2sZM2qcm2dUGpeo4+gZqBToLWKEBAGCSlkWEtgS19A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/toolbar": "3.0.0-beta.19",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/toggle": "^3.9.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.9.0.tgz",
+      "integrity": "sha512-YxHLqL/LZrgwYGKzlQ96Fgt6gC+Q1L8k56sD51jJAtiD+YtT/pKJfK1zjZ3rtHtPTDYzosJ8vFgOmZNpnKQpXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/calendar": "^3.8.3",
+        "@react-types/button": "^3.13.0",
+        "@react-types/calendar": "^3.7.3",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.16.0.tgz",
+      "integrity": "sha512-XPaMz1/iVBG6EbJOPYlNtvr+q4f0axJeoIvyzWW3ciIdDSX/3jYuFg/sv/b3OQQl389cbQ/WUBQyWre/uXWVEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.0",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/toggle": "^3.12.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/checkbox": "^3.7.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/toggle": "^3.9.0",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/collections": {
+      "version": "3.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/collections/-/collections-3.0.0-rc.4.tgz",
+      "integrity": "sha512-efcQW/Kly5ebS2kWrVRBD7yEl3b0FdQE/dDL/87skVMW0Vh6AtUgCShZfcOcGAIqvG7m6QItdUHwAilDA61riQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/color/-/color-3.1.0.tgz",
+      "integrity": "sha512-95qcCmz5Ss6o1Z4Z7X3pEEQxoUA83qGNQkpjOvobcHbNWKfhvOAsUzdBleOx2NpyBzY16OAnhWR7PJZwR4AqiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/numberfield": "^3.12.0",
+        "@react-aria/slider": "^3.8.0",
+        "@react-aria/spinbutton": "^3.6.17",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/visually-hidden": "^3.8.26",
+        "@react-stately/color": "^3.9.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-types/color": "^3.1.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.13.0.tgz",
+      "integrity": "sha512-eBa8aWcL3Ar/BvgSaqYDmNQP70LPZ7us2myM31QQt2YDRptqGHd44wzXCts9SaDVIeMVy+AEY2NkuxrVE6yNrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/listbox": "^3.14.7",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/menu": "^3.19.0",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/combobox": "^3.11.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/combobox": "^3.13.7",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.15.0.tgz",
+      "integrity": "sha512-AONeLj7sMKz4JmzCu4bhsqwcNFXCSWoaBhi4wOJO9+WYmxudn5mSI9ez8NMCVn+s5kcYpyvzrrAFf/DvQ4UDgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/number": "^3.6.4",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/form": "^3.1.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/spinbutton": "^3.6.17",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/datepicker": "^3.15.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/calendar": "^3.7.3",
+        "@react-types/datepicker": "^3.13.0",
+        "@react-types/dialog": "^3.5.20",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.28",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.28.tgz",
+      "integrity": "sha512-S9dgdFBQc9LbhyBiHwGPSATwtvsIl6h+UnxDJ4oKBSse+wxdAyshbZv2tyO5RFbe3k73SAgU7yKocfg7YyRM0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/dialog": "^3.5.20",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/disclosure": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/disclosure/-/disclosure-3.0.7.tgz",
+      "integrity": "sha512-g17smH+5v7B6JijzN20rIRUmE2N8owYK/4blR6tIyS+oLIHr+Crkt1ErNoUWynibj2/4gDd9KGrKyzwB4vxK9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/disclosure": "^3.0.6",
+        "@react-types/button": "^3.13.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dnd": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.11.0.tgz",
+      "integrity": "sha512-jr47o7Fy55eYjSKWqRyuWKPnynpgC4cE9YXnYg5xa+1woRefIF2IyteOxgSHeX16+6ef2UDSsvC61T3gS6NWxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/dnd": "^3.6.1",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.21.0.tgz",
+      "integrity": "sha512-7NEGtTPsBy52EZ/ToVKCu0HSelE3kq9qeis+2eEq90XSuJOMaDHUQrA7RC2Y89tlEwQB31bud/kKRi9Qme1dkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -2183,16 +2539,424 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.1.tgz",
-      "integrity": "sha512-ntLrlgqkmZupbbjekz3fE/n3eQH2vhncx8gUp0+N+GttKWevx7jos11JUBjnJwb1RSOPgRUFcrluOqBp0VgcfQ==",
+    "node_modules/@react-aria/form": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.1.0.tgz",
+      "integrity": "sha512-aDAOZafrn0V8e09mDAtCvc+JnpnkFM9X8cbI5+fdXsXAA+JxO+3uRRfnJHBlIL0iLc4C4OVWxBxWToV95pg1KA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-aria/utils": "^3.29.0",
-        "@react-stately/flags": "^3.1.1",
-        "@react-types/shared": "^3.29.1",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.14.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.14.3.tgz",
+      "integrity": "sha512-O4Ius5tJqKcMGfQT6IXD4MnEOeq6f/59nKmfCLTXMREFac/oxafqanUx3zrEVYbaqLOjEmONcd8S61ptQM6aPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/grid": "^3.11.4",
+        "@react-stately/selection": "^3.20.4",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/gridlist": {
+      "version": "3.13.3",
+      "resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.13.3.tgz",
+      "integrity": "sha512-U2x/1MpdrAgK/vay2s2nVSko4WysajlMS+L8c18HE/ig2to+C8tCPWH2UuK4jTQWrK5x/PxTH+/yvtytljnIuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/grid": "^3.14.3",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/list": "^3.12.4",
+        "@react-stately/tree": "^3.9.1",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.11.tgz",
+      "integrity": "sha512-1mxUinHbGJ6nJ/uSl62dl48vdZfWTBZePNF/wWQy98gR0qNFXLeusd7CsEmJT1971CR5i/WNYUo1ezNlIJnu6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/message": "^3.1.8",
+        "@internationalized/number": "^3.6.4",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.4.tgz",
+      "integrity": "sha512-HBQMxgUPHrW8V63u9uGgBymkMfj6vdWbB0GgUJY49K9mBKMsypcHeWkWM6+bF7kxRO728/IK8bWDV6whDbqjHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/flags": "^3.1.2",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.20",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.20.tgz",
+      "integrity": "sha512-Hw7OsC2GBnjptyW1lC1+SNoSIZA0eIh02QnNDr1XX2S+BPfn958NxoI7sJIstO/TUpQVNqdjEN/NI6+cyuJE6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/landmark": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/landmark/-/landmark-3.0.5.tgz",
+      "integrity": "sha512-klUgRGQyTv5qWFQ0EMMLBOLa87qSTGjWoiMvytL9EgJCACkn/OzNMPbqVSkMADvadDyWCMWFYWvfweLxl3T5yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.8.4.tgz",
+      "integrity": "sha512-7cPRGIo7x6ZZv1dhp2xGjqLR1snazSQgl7tThrBDL5E8f6Yr7SVpxOOK5/EBmfpFkhkmmXEO/Fgo/GPJdc6Vmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/link": "^3.6.3",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.14.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.14.7.tgz",
+      "integrity": "sha512-U5a+AIDblaeQTIA1MDFUaYIKoPwPNAuY7SwkuA5Z7ClDOeQJkiyExmAoKcUXwUkrLULQcbOPKr401q38IL3T7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/list": "^3.12.4",
+        "@react-types/listbox": "^3.7.2",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.4.tgz",
+      "integrity": "sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.19.0.tgz",
+      "integrity": "sha512-VLUGbZedKJvK2OFWEpa86GPIaj9QcWox/R9JXmNk6nyrAz/V46OBQENdliV26PEdBZgzrVxGvmkjaH7ZsN/32Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/menu": "^3.9.6",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/tree": "^3.9.1",
+        "@react-types/button": "^3.13.0",
+        "@react-types/menu": "^3.10.3",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/meter": {
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.25.tgz",
+      "integrity": "sha512-6IqOnwuEt8z6UDy8Ru3ZZRZIUiELD0N3Wi/udMfR8gz4oznutvnRCMpRXkVVaVLYQfRglybu2/Lxfe+rq8WiRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/progress": "^3.4.25",
+        "@react-types/meter": "^3.4.11",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/numberfield": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.12.0.tgz",
+      "integrity": "sha512-JkgkjYsZ9lN5m3//X3buOKVrA/QJEeeXJ+5T5r6AmF29YdIhD1Plf5AEOWoRpZWQ25chH7FI/Orsf4h3/SLOpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/spinbutton": "^3.6.17",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/numberfield": "^3.10.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/numberfield": "^3.8.13",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.28.0.tgz",
+      "integrity": "sha512-qaHahAXTmxXULgg2/UfWEIwfgdKsn27XYryXAWWDu2CAZTcbI+5mGwYrQZSDWraM6v5PUUepzOVvm7hjTqiMFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/visually-hidden": "^3.8.26",
+        "@react-stately/overlays": "^3.6.18",
+        "@react-types/button": "^3.13.0",
+        "@react-types/overlays": "^3.9.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.25",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.25.tgz",
+      "integrity": "sha512-KD9Gow+Ip6ZCBdsarR+Hby3c4d99I6L95Ruf7tbCh4ut9i9Dbr+x99OwhpAbT0g549cOyeIqxutPkT+JuzrRuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/progress": "^3.5.14",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.12.0.tgz",
+      "integrity": "sha512-//0zZUuHtbm6uZR9+sNRNzVcQpjJKjZj57bDD0lMNj3NZp/Tkw+zXIFy6j1adv3JMe6iYkzEgaB7YRDD1Fe/ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/form": "^3.1.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/radio": "^3.11.0",
+        "@react-types/radio": "^3.9.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/searchfield": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.8.7.tgz",
+      "integrity": "sha512-15jfALRyz5EAA5tvIELVfUlqTFdk8oG442OiS3Xq/jJij8uKRzwUdnL57EVTFYyg+VMLp/t5wX+obXYcRG+kdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/searchfield": "^3.5.14",
+        "@react-types/button": "^3.13.0",
+        "@react-types/searchfield": "^3.6.4",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/select": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.16.0.tgz",
+      "integrity": "sha512-UkiLSxMOKWW24qnhZdOObkFLpauvmu0T6wuPXbdQgwlis/UeLzDamPAWc6loRFJgHCpJftaaaWVQG3ks4NX7ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/listbox": "^3.14.7",
+        "@react-aria/menu": "^3.19.0",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/visually-hidden": "^3.8.26",
+        "@react-stately/select": "^3.7.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/select": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.25.0.tgz",
+      "integrity": "sha512-Q3U0Ya0PTP/TR0a2g+7YEbFVLphiWthmEkHyvOx9HsKSjE8w9wXY3C14DZWKskB/BBrXKJuOWxBDa0xhC83S+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/selection": "^3.20.4",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/separator": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.4.11.tgz",
+      "integrity": "sha512-WwYEb7Wga4YQvlEwbzlVcVkfByullcORKtIe30pmh1YkTRRVJhbRPaE/mwcSMufbfjSYdtDavxmF+WY7Tdb9/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.8.0.tgz",
+      "integrity": "sha512-D7Sa7q21cV3gBid7frjoYw6924qYqNdJn2oai1BEemHSuwQatRlm1o2j+fnPTy9sYZfNOqXYnv5YjEn0o1T+Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/slider": "^3.7.0",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/slider": "^3.8.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.17.tgz",
+      "integrity": "sha512-gdGc3kkqpvFUd9XsrhPwQHMrG2TY0LVuGGgjvaZwF/ONm9FMz393ogCM0P484HsjU50hClO+yiRRgNjdwDIzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
         "@swc/helpers": "^0.5.0"
       },
       "peerDependencies": {
@@ -2201,9 +2965,9 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.8",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
-      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
+      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2215,16 +2979,216 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-aria/utils": {
-      "version": "3.29.0",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.29.0.tgz",
-      "integrity": "sha512-jSOrZimCuT1iKNVlhjIxDkAhgF7HSp3pqyT6qjg/ZoA0wfqCi/okmrMPiWSAKBnkgX93N8GYTLT3CIEO6WZe9Q==",
+    "node_modules/@react-aria/switch": {
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.7.6.tgz",
+      "integrity": "sha512-C+Od8hZNZCf3thgtZnZKzHl5b/63Q9xf+Pw6ugLA1qaKazwp46x1EwUVVqVhfAeVhmag++eHs8Lol5ZwQEinjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@react-aria/ssr": "^3.9.8",
-        "@react-stately/flags": "^3.1.1",
-        "@react-stately/utils": "^3.10.6",
-        "@react-types/shared": "^3.29.1",
+        "@react-aria/toggle": "^3.12.0",
+        "@react-stately/toggle": "^3.9.0",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/switch": "^3.5.13",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.17.6.tgz",
+      "integrity": "sha512-PSEaeKOIazVEaykeTLudPbDLytJgOPLZJalS/xXY0/KL+Gi0Olchmz4tvS0WBe87ChmlVi6GQqU+stk23aZVWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/grid": "^3.14.3",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/visually-hidden": "^3.8.26",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/table": "^3.14.4",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/table": "^3.13.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.10.6.tgz",
+      "integrity": "sha512-L8MaE7+bu6ByDOUxNPpMMYxdHULhKUfBoXdsSsXqb1z3QxdFW2zovfag0dvpyVWB6ALghX2T0PlTUNqaKA5tGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/tabs": "^3.8.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/tabs": "^3.3.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tag": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.7.0.tgz",
+      "integrity": "sha512-nU0Sl7u82RBn8XLNyrjkXhtw+xbJD9fyjesmDu7zeOq78e4eunKW7OZ/9+t+Lyu5wW+B7vKvetIgkdXKPQm3MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.3",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/list": "^3.12.4",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.18.0.tgz",
+      "integrity": "sha512-kCwbyDHi2tRaD/OjagA3m3q2mMZUPeXY7hRqhDxpl2MwyIdd+/PQOJLM8tZr5+m2zvBx+ffOcjZMGTMwMtoV5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.1.0",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/textfield": "^3.12.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toast": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/toast/-/toast-3.0.6.tgz",
+      "integrity": "sha512-PoCLWoZzdHIMYY0zIU3WYsHAHPS52sN1gzGRJ+cr5zogU8wwg8lwFZCvs/yql0IhQLsO930zcCXWeL/NsCMrlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/landmark": "^3.0.5",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/toast": "^3.1.2",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.12.0.tgz",
+      "integrity": "sha512-JfcrF8xUEa2CbbUXp+WQiTBVwSM/dm21v5kueQlksvLfXG6DGE8/zjM6tJFErrFypAasc1JXyrI4dspLOWCfRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/toggle": "^3.9.0",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.19",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.19.tgz",
+      "integrity": "sha512-G4sgtOUTUUJHznXlpKcY64SxD2gKOqIQXZXjWTVcY/Q5hAjl8gbTt5XIED22GmeIgd/tVl6+lddGj6ESze4vSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.6.tgz",
+      "integrity": "sha512-lW/PegiswGLlCP0CM4FH2kbIrEe4Li2SoklzIRh4nXZtiLIexswoE5/5af7PMtoMAl31or6fHZleVLzZD4VcfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/tooltip": "^3.5.6",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/tooltip": "^3.4.19",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tree": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/tree/-/tree-3.1.2.tgz",
+      "integrity": "sha512-duyAoxSIzgIEP1UvCivx8uY7GZxo8nhfSsHW77GO+UMgwBjWkrvHnYQXBYbLq1GLqLxuDN+U7SFe8Az7+HcbOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/gridlist": "^3.13.3",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/tree": "^3.9.1",
+        "@react-types/button": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.30.0.tgz",
+      "integrity": "sha512-ydA6y5G1+gbem3Va2nczj/0G0W7/jUVo/cbN10WA5IizzWIwMP5qhFr7macgbKfHMkZ+YZC3oXnt2NNre5odKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.10",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
         "@swc/helpers": "^0.5.0",
         "clsx": "^2.0.0"
       },
@@ -2233,19 +3197,490 @@
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
+    "node_modules/@react-aria/virtualizer": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/virtualizer/-/virtualizer-4.1.8.tgz",
+      "integrity": "sha512-dwaJuqjtpVKTaWJS+PEe+tymqVzOjY8cZLvmSDC4uUizHOUh+O/NvoKWtwSQnB4/GxIEvdgLxYTTvVTf8jdKgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-stately/virtualizer": "^4.4.2",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.26",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.26.tgz",
+      "integrity": "sha512-Lz36lTVaQbv5Kn74sPv0l9SnLQ5XHKCoq2zilP14Eb4QixDIqR7Ovj43m+6wi9pynf29jtOb/8D/9jrTjbmmgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/autocomplete": {
+      "version": "3.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/autocomplete/-/autocomplete-3.0.0-beta.3.tgz",
+      "integrity": "sha512-YfP/TrvkOCp6j7oqpZxJSvmSeXn+XtbKSOiBOuo+m2zCIhW2ncThmDB9uAUOkpmikDv/LkGKni40RQE8USdGdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.8.3.tgz",
+      "integrity": "sha512-HTWD6ZKQcXDlvj6glEEG0oi2Tpkaw19y5rK526s04zJs894wFqM9PK0WHthEYqjCeQJ5B/OkyG19XX4lENxnZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/calendar": "^3.7.3",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.7.0.tgz",
+      "integrity": "sha512-opViVhNvxFVHjXhM4nA/E03uvbLazsIKloXX9JtyBCZAQRUag17dpmkekfIkHvP4o7z7AWFoibD8JBFV1IrMcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.6.tgz",
+      "integrity": "sha512-S158RKWGZSodbJXKZDdcnrLzFxzFmyRWDNakQd1nBGhSrW2JV8lDn9ku5Og7TrjoEpkz//B2oId648YT792ilw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/color": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/color/-/color-3.9.0.tgz",
+      "integrity": "sha512-9eG0gDxVIu+A+DTdfwyYuU4pR788pVdq1Snpk8el787OsOb5WiuT4C4VWJb5Qbrq2PiFhhZmxuJXpzz4B1gW3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.4",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/numberfield": "^3.10.0",
+        "@react-stately/slider": "^3.7.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/color": "^3.1.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.11.0.tgz",
+      "integrity": "sha512-W9COXdSOC+uqCZrRHJI0K7emlPb/Tx4A89JHWBcFmiAk+hs1Cnlyjw3aaqEiT8A8/HxDNMO9QcfisWC1iNyE9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/list": "^3.12.4",
+        "@react-stately/overlays": "^3.6.18",
+        "@react-stately/select": "^3.7.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/combobox": "^3.13.7",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/data": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.13.2.tgz",
+      "integrity": "sha512-xdCqR8dJ3cnvO8EdCeuQ335dOuBqEV4z/3LnpxmR11gyn8dWwtY5O794g5+AS0KqCgd9W0v7iBrRywq5UT2pCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.15.0.tgz",
+      "integrity": "sha512-OuBx+h802CoANy6KNR6XuZCndiyRf9vpB32CYZX86nqWy21GSTeT73G41ze5cAH88A/6zmtpYK24nTlk8bdfWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/overlays": "^3.6.18",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/datepicker": "^3.13.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/disclosure": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/disclosure/-/disclosure-3.0.6.tgz",
+      "integrity": "sha512-tR2IzcS7JbgAXy9U0gxQQGRHKIqgC7nj3xsY5U9QGCE1BKzwf/84iDE63AXpLRje31yuYzwXsJs6UrE9wSjb3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/dnd": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.6.1.tgz",
+      "integrity": "sha512-cbBLptL+tpXFQ0oU0v6GBtSvzP0doohyhCIr8pOzk6aYutFI0c5JZw8LGoKN/GLfXkm7iPyrfCKeKqDlDTHCzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/selection": "^3.20.4",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-stately/flags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
-      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.2.tgz",
+      "integrity": "sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
     },
+    "node_modules/@react-stately/form": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.2.0.tgz",
+      "integrity": "sha512-PfefxvT7/BIhAGpD4oQpdcxnL8cfN0ZTQxQq+Wmb9z3YzK1oM8GFxb8eGdDRG71JeF8WUNMAQVZFhgl00Z/YKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.4.tgz",
+      "integrity": "sha512-oaXFSk2eM0PJ0GVniGA0ZlTpAA0AL0O4MQ7V3cHqZAQbwSO0n2pT31GM0bSVnYP/qTF5lQHo3ECmRQCz0fVyMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/selection": "^3.20.4",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/layout": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-4.4.0.tgz",
+      "integrity": "sha512-PGpJBCo8yzasdYVGHFp/vHdzaJsagUOSc/bAQubVpKpKK+RVgSpk2uCo1O8sYjI5MxSVrhlhqGbVfV1O6Tqksw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/table": "^3.14.4",
+        "@react-stately/virtualizer": "^4.4.2",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/table": "^3.13.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.12.4.tgz",
+      "integrity": "sha512-r7vMM//tpmagyNlRzl2NFPPtx+az5R9pM6q7aI4aBf6/zpZt2eX2UW5gaDTGlkQng7r6OGyAgJD52jmGcCJk7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.6.tgz",
+      "integrity": "sha512-2rVtgeVAiyr7qL8BhmCK/4el49rna/5kADRH5NfPdpXw8ZzaiiHq2RtX443Txj7pUU82CJWQn+CRobq7k6ZTEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.18",
+        "@react-types/menu": "^3.10.3",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/numberfield": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.10.0.tgz",
+      "integrity": "sha512-6C8ML4/e2tcn01BRNfFLxetVaWwz0n0pVROnVpo8p761c6lmTqohqEMNcXCVNw9H0wsa1hug2a1S5PcN2OXgag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/number": "^3.6.4",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/numberfield": "^3.8.13",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.18",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.18.tgz",
+      "integrity": "sha512-g8n2FtDCxIg2wQ09R7lrM2niuxMPCdP17bxsPV9hyYnN6m42aAKGOhzWrFOK+3phQKgk/E1JQZEvKw1cyyGo1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/overlays": "^3.9.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.11.0.tgz",
+      "integrity": "sha512-hsCmKb9e/ygmzBADFYIGpEQ43LrxjWnlKESgxphvlv0Klla4d6XLAYSFOTX1kcjSztpvVWrdl4cIfmKVF1pz2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/radio": "^3.9.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/searchfield": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.14.tgz",
+      "integrity": "sha512-OAycTULyF/UWy7Odyzw5lZV2yWH+Cy7fWsZxDUedeUs4Aiwbb6D4ph9pGb0RvhD4S3+B490a2ijGgfsaDeorMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/searchfield": "^3.6.4",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.7.0.tgz",
+      "integrity": "sha512-OWLOCKBEj8/XI+vzBSSHQAJu0Hf9Xl/flMhYh47f2b45bO++DRLcVsi8nycPNisudvK6xMQ8a/h4FwjePrCXfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/list": "^3.12.4",
+        "@react-stately/overlays": "^3.6.18",
+        "@react-types/select": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.4.tgz",
+      "integrity": "sha512-Hxmc6NtECStYo+Z2uBRhQ80KPhbSF7xXv9eb4qN8dhyuSnsD6c0wc6oAJsv18dldcFz8VrD48aP/uff9mj0hxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.7.0.tgz",
+      "integrity": "sha512-quxqkyyxrxLELYEkPrIrucpVPdYDK8yyliv/vvNuHrjuLRIvx6UmssxqESp2EpZfwPYtEB29QXbAKT9+KuXoCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/slider": "^3.8.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.14.4.tgz",
+      "integrity": "sha512-uhwk8z3DemozD+yHBjSa4WyxKczpDkxhJhW7ZVOY+1jNuTYxc9/JxzPsHICrlDVV8EPWwwyMUz8eO/8rKN7DbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/flags": "^3.1.2",
+        "@react-stately/grid": "^3.11.4",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/table": "^3.13.2",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.8.4.tgz",
+      "integrity": "sha512-2Tr4yXkcNDLyyxrZr+c4FnAW/wkSim3UhDUWoOgTCy3mwlQzdh9r5qJrOZRghn1QvF7p8Ahp7O7qxwd2ZGJrvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.12.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/tabs": "^3.3.17",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toast": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/toast/-/toast-3.1.2.tgz",
+      "integrity": "sha512-HiInm7bck32khFBHZThTQaAF6e6/qm57F4mYRWdTq8IVeGDzpkbUYibnLxRhk0UZ5ybc6me+nqqPkG/lVmM42Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.9.0.tgz",
+      "integrity": "sha512-1URd97R5nbFF9Hc1nQBhvln55EnOkLNz6pjtXU7TCnV4tYVbe+tc++hgr5XRt6KAfmuXxVDujlzRc6QjfCn0cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/checkbox": "^3.10.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.6.tgz",
+      "integrity": "sha512-BnOtE7726t1sCKPGbwzzEtEx40tjpbJvw5yqpoVnAV0OLfrXtLVYfd7tWRHmZOYmhELaUnY+gm3ZFYtwvnjs+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.18",
+        "@react-types/tooltip": "^3.4.19",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.9.1.tgz",
+      "integrity": "sha512-dyoPIvPK/cs03Tg/MQSODi2kKYW1zaiOG9KC2P0c8b44mywU2ojBKzhSJky3dBkJ4VVGy7L+voBh50ELMjEa8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/utils": "^3.10.8",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@react-stately/utils": {
-      "version": "3.10.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
-      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.8.tgz",
+      "integrity": "sha512-SN3/h7SzRsusVQjQ4v10LaVsDc81jyyR0DD5HnsQitm/I5WDpaSr2nRHtyloPFU48jlql1XX/S04T2DLQM7Y3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -2254,11 +3689,363 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
-    "node_modules/@react-types/shared": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.1.tgz",
-      "integrity": "sha512-KtM+cDf2CXoUX439rfEhbnEdAgFZX20UP2A35ypNIawR7/PFFPjQDWyA2EnClCcW/dLWJDEPX2U8+EJff8xqmQ==",
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.4.2.tgz",
+      "integrity": "sha512-csU/Bbq1+JYCXlF3wKHa690EhV4/uuK5VwZZvi9jTMqjblDiNUwEmIcx78J8aoadjho5wgRw3ddE9NPDGcVElA==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.30.0",
+        "@react-types/shared": "^3.31.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/autocomplete": {
+      "version": "3.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@react-types/autocomplete/-/autocomplete-3.0.0-alpha.33.tgz",
+      "integrity": "sha512-443avwJleeBmTR96WduQpq+D4murkmZLueen/2aazRST9nylN7u8w0DSW+84c9ENroSpfHI6Nf7epmg1LxLaOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/combobox": "^3.13.7",
+        "@react-types/searchfield": "^3.6.4",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.15",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.15.tgz",
+      "integrity": "sha512-0RsymrsOAsx443XRDJ1krK+Lusr4t0qqExmzFe7/XYXOn/RbGKjzSdezsoWfTy8Hjks0YbfQPVKnNxg9LKv4XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.6.3",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.13.0.tgz",
+      "integrity": "sha512-hwvcNnBjDeNvWheWfBhmkJSzC48ub5rZq0DnpemB3XKOvv5WcF9p6rrQZsQ3egNGkh0Z+bKfr2QfotgOkccHSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.7.3.tgz",
+      "integrity": "sha512-gofPgVpSawJ0iGO01SbVH46u3gdykHlGT5BfGU1cRnsOR2tJX38dekO/rnuGsMQYF0+kU6U9YVae+XoOFJNnWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.10.0.tgz",
+      "integrity": "sha512-DJ84ilBDvZddE/Sul97Otee4M6psrPRaJm2a1Bc7M3Y5UKo6d6RGXdcDarRRpbnS7BeAbVanKiMS2ygI9QHh9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-types/color/-/color-3.1.0.tgz",
+      "integrity": "sha512-mqx76zdq/GyI7hdx+NTdTrCG6qmf1Uk3w/zWKF80OAesLqqs9XavQQZlRPu1Cg/fHiAHIBOLYTnLf8w+T2IMsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0",
+        "@react-types/slider": "^3.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.7.tgz",
+      "integrity": "sha512-R7MQ4Qm4fryo6FCg3Vo/l9wxkYVG05trsLbxzMvvxCMkpcoHUPhy8Ll33eXA3YP74Rs/IaM9d0d/amSUZ4M9wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.13.0.tgz",
+      "integrity": "sha512-AG/iGcdQ5SVSjw8Ta7bCdGNkMda+e+Z7lOHxDawL44SII8LtZroBDlaCpb178Tvo17bBfJ6TvWXlvSpBY8GPRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@react-types/calendar": "^3.7.3",
+        "@react-types/overlays": "^3.9.0",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.20.tgz",
+      "integrity": "sha512-ebn8jW/xW/nmRATaWIPHVBIpIFWSaqjrAxa58f5TXer5FtCD9pUuzAQDmy/o22ucB0yvn6Kl+fjb3SMbMdALZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.0",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.14",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.14.tgz",
+      "integrity": "sha512-P+FXOQR/ISxLfBbCwgttcR1OZGqOknk7Ksgrxf7jpc4PuyUC048Jf+FcG+fARhoUeNEhv6kBXI5fpAB6xqnDhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.4.tgz",
+      "integrity": "sha512-8XNn7Czhl+D1b2zRwdO8c3oBJmKgevT/viKJB4qBVFOhK0l/p3HYDZUMdeclvUfSt4wx4ASpI7MD3v1vmN54oA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.6.3.tgz",
+      "integrity": "sha512-XIYEl9ZPa5mLy8uGQabdhPaFVmnvxNSYF59t0vs/IV0yxeoPvrjKjRAbXS+WP9zYMXIkHYNYYucriCkqKhotJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.7.2.tgz",
+      "integrity": "sha512-MRpBhApR1jJNASoVWsEvH5vf89TJw+l9Lt1ssawop0K2iYF5PmkthRdqcpYcTkFu5+f5QvFchVsNJ3TKD4cf2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.10.3.tgz",
+      "integrity": "sha512-Vd3t7fEbIOiq7kBAHaihfYf+/3Fuh0yK2KNjJ70BPtlAhMRMDVG3m0PheSTm3FFfj+uAdQdfc2YKPnMBbWjDuQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.0",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/meter": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.4.11.tgz",
+      "integrity": "sha512-c4jnDWFxDp09fNpCDrq6l2RxOxcolmf/frvdtVA/d4SGvfEOoqeUakpVDuOqDD0bU58tQPG3fqT2zH8vpWiJew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/progress": "^3.5.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/numberfield": {
+      "version": "3.8.13",
+      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.13.tgz",
+      "integrity": "sha512-zRSqInmxOTQJZt2fjAhuQK3Wa1vCOlKsRzUVvxTrE8gtQxlgFxirmobuUnjTEhwkFyb0bq8GvVfQV1E95Si2yw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.9.0.tgz",
+      "integrity": "sha512-T2DqMcDN5p8vb4vu2igoLrAtuewaNImLS8jsK7th7OjwQZfIWJn5Y45jSxHtXJUddEg1LkUjXYPSXCMerMcULw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.14",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.14.tgz",
+      "integrity": "sha512-GeGrjOeHR/p5qQ1gGlN68jb+lL47kuddxMgdR1iEnAlYGY4OtJoEN/EM5W2ZxJRKPcJmzdcY/p/J0PXa8URbSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.9.0.tgz",
+      "integrity": "sha512-phndlgqMF6/9bOOhO3le00eozNfDU1E7OHWV2cWWhGSMRFuRdf7/d+NjVtavCX75+GJ50MxvXk+KB0fjTuvKyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/searchfield": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.6.4.tgz",
+      "integrity": "sha512-gRVWnRHf7pqU0lBVlkU6XsLxvaWTPnn0EomddIBCVh0msVIyvEea8CXJppu7EpvRh+grNpiMEYeijQ+u8hixlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0",
+        "@react-types/textfield": "^3.12.4"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.10.0.tgz",
+      "integrity": "sha512-+xJwYWJoJTCGsaiPAqb6QB79ub1WKIHSmOS9lh/fPUXfUszVs05jhajaN9KjrKmnXds5uh4u6l1JH5J1l2K5pw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.31.0.tgz",
+      "integrity": "sha512-ua5U6V66gDcbLZe4P2QeyNgPp4YWD1ymGA6j3n+s8CGExtrCPe64v+g4mvpT8Bnb985R96e4zFT61+m0YCwqMg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.8.0.tgz",
+      "integrity": "sha512-eN6Fd3YCPseGfvfOJDtn9Lh9CrAb8tF3cTAprEcpnGrsxmdW9JQpcuciYuLM871X5D2fYg4WaYMpZaiYssjxBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.13.tgz",
+      "integrity": "sha512-C2EhKBu7g7xhKboPPxhyKtROEti80Ck7TBnKclXt0D4LiwbzpR3qGfuzB+7YFItnhiauP7Uxe+bAfM5ojjtm9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.13.2.tgz",
+      "integrity": "sha512-3/BpFIWHXTcGgQEfip87gMNCWPtPNsc3gFkW4qtsevQ+V0577KyNyvQgvFrqMZKnvz3NWFKyshBb7PTevsus4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.17.tgz",
+      "integrity": "sha512-cLcdxWNJe0Kf/pKuPQbEF9Fl+axiP4gB/WVjmAdhCgQ5LCJw2dGcy1LI1SXrlS3PVclbnujD1DJ8z1lIW4Tmww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.12.4.tgz",
+      "integrity": "sha512-cOgzI1dT8X1JMNQ9u2UKoV2L28ROkbFEtzY9At0MqTZYYSxYp3Q7i+XRqIBehu8jOMuCtN9ed9EgwVSfkicyLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.19.tgz",
+      "integrity": "sha512-OR/pwZReWbCIxuHJYB1L4fTwliA+mzVvUJMWwXIRy6Eh5d07spS3FZEKFvOgjMxA1nyv5PLf8eyr5RuuP1GGAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.9.0",
+        "@react-types/shared": "^3.31.0"
+      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
@@ -5976,6 +7763,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -6523,6 +8316,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -9960,6 +11759,18 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
@@ -12826,6 +14637,100 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-aria": {
+      "version": "3.42.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.42.0.tgz",
+      "integrity": "sha512-lZF1tVmcO6mTWBHpmo4r58lBxIkt/DeF1gu5vrLv2lF4H213VGdSIG8ogQgMc2NaLHK720wafYVM2m5pRUIKdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/breadcrumbs": "^3.5.27",
+        "@react-aria/button": "^3.14.0",
+        "@react-aria/calendar": "^3.9.0",
+        "@react-aria/checkbox": "^3.16.0",
+        "@react-aria/color": "^3.1.0",
+        "@react-aria/combobox": "^3.13.0",
+        "@react-aria/datepicker": "^3.15.0",
+        "@react-aria/dialog": "^3.5.28",
+        "@react-aria/disclosure": "^3.0.7",
+        "@react-aria/dnd": "^3.11.0",
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/gridlist": "^3.13.3",
+        "@react-aria/i18n": "^3.12.11",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/label": "^3.7.20",
+        "@react-aria/landmark": "^3.0.5",
+        "@react-aria/link": "^3.8.4",
+        "@react-aria/listbox": "^3.14.7",
+        "@react-aria/menu": "^3.19.0",
+        "@react-aria/meter": "^3.4.25",
+        "@react-aria/numberfield": "^3.12.0",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/progress": "^3.4.25",
+        "@react-aria/radio": "^3.12.0",
+        "@react-aria/searchfield": "^3.8.7",
+        "@react-aria/select": "^3.16.0",
+        "@react-aria/selection": "^3.25.0",
+        "@react-aria/separator": "^3.4.11",
+        "@react-aria/slider": "^3.8.0",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/switch": "^3.7.6",
+        "@react-aria/table": "^3.17.6",
+        "@react-aria/tabs": "^3.10.6",
+        "@react-aria/tag": "^3.7.0",
+        "@react-aria/textfield": "^3.18.0",
+        "@react-aria/toast": "^3.0.6",
+        "@react-aria/tooltip": "^3.8.6",
+        "@react-aria/tree": "^3.1.2",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/visually-hidden": "^3.8.26",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria-components": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.11.0.tgz",
+      "integrity": "sha512-+NxjfCiswbssoCNPJ1H5NEPnM2G7whM5bZSjkSUPXS3ZbbqQ1KSmSWHT34V4mrU+kpFfEZeZ/6E6GBYfugndig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.2",
+        "@internationalized/string": "^3.2.7",
+        "@react-aria/autocomplete": "3.0.0-beta.6",
+        "@react-aria/collections": "3.0.0-rc.4",
+        "@react-aria/dnd": "^3.11.0",
+        "@react-aria/focus": "^3.21.0",
+        "@react-aria/interactions": "^3.25.4",
+        "@react-aria/live-announcer": "^3.4.4",
+        "@react-aria/overlays": "^3.28.0",
+        "@react-aria/ssr": "^3.9.10",
+        "@react-aria/toolbar": "3.0.0-beta.19",
+        "@react-aria/utils": "^3.30.0",
+        "@react-aria/virtualizer": "^4.1.8",
+        "@react-stately/autocomplete": "3.0.0-beta.3",
+        "@react-stately/layout": "^4.4.0",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/table": "^3.14.4",
+        "@react-stately/utils": "^3.10.8",
+        "@react-stately/virtualizer": "^4.4.2",
+        "@react-types/form": "^3.7.14",
+        "@react-types/grid": "^3.3.4",
+        "@react-types/shared": "^3.31.0",
+        "@react-types/table": "^3.13.2",
+        "@swc/helpers": "^0.5.0",
+        "client-only": "^0.0.1",
+        "react-aria": "^3.42.0",
+        "react-stately": "^3.40.0",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-7.1.1.tgz",
@@ -12876,6 +14781,43 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-stately": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.40.0.tgz",
+      "integrity": "sha512-Icg2q1pxTskx2dph3cFUu9RUQcInq25WZfUcKroX1Kl4jWxBobnfMvuxvJHHkysJh77IsnLmhF3+8If5oCoMFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/calendar": "^3.8.3",
+        "@react-stately/checkbox": "^3.7.0",
+        "@react-stately/collections": "^3.12.6",
+        "@react-stately/color": "^3.9.0",
+        "@react-stately/combobox": "^3.11.0",
+        "@react-stately/data": "^3.13.2",
+        "@react-stately/datepicker": "^3.15.0",
+        "@react-stately/disclosure": "^3.0.6",
+        "@react-stately/dnd": "^3.6.1",
+        "@react-stately/form": "^3.2.0",
+        "@react-stately/list": "^3.12.4",
+        "@react-stately/menu": "^3.9.6",
+        "@react-stately/numberfield": "^3.10.0",
+        "@react-stately/overlays": "^3.6.18",
+        "@react-stately/radio": "^3.11.0",
+        "@react-stately/searchfield": "^3.5.14",
+        "@react-stately/select": "^3.7.0",
+        "@react-stately/selection": "^3.20.4",
+        "@react-stately/slider": "^3.7.0",
+        "@react-stately/table": "^3.14.4",
+        "@react-stately/tabs": "^3.8.4",
+        "@react-stately/toast": "^3.1.2",
+        "@react-stately/toggle": "^3.9.0",
+        "@react-stately/tooltip": "^3.5.6",
+        "@react-stately/tree": "^3.9.1",
+        "@react-types/shared": "^3.31.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "electron-squirrel-startup": "^1.0.1",
     "lucide-react": "^0.511.0",
     "react": "^19.1.0",
+    "react-aria-components": "^1.11.0",
     "react-dom": "^19.1.0"
   }
 }

--- a/src/renderer/ui/Button/Button.stories.ts
+++ b/src/renderer/ui/Button/Button.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
-
 import { Button } from "./Button";
+
 import { Sparkles } from "lucide-react";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
@@ -16,7 +16,7 @@ const meta: Meta<typeof Button> = {
   tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-  args: { onClick: fn(), size: "default", children: "Button" },
+  args: { onPress: fn(), size: "default", children: "Button" },
   argTypes: {
     variant: {
       control: { type: "select" },

--- a/src/renderer/ui/Button/Button.tsx
+++ b/src/renderer/ui/Button/Button.tsx
@@ -1,9 +1,13 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import styles from "./Button.module.css";
 import { LucideIcon } from "lucide-react";
-import { forwardRef } from "react";
-import { Button as HeadlessButton } from "@headlessui/react";
-import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip";
+import React, { forwardRef } from "react";
+import {
+  Button as ReactAriaButton,
+  ButtonProps as ReactAriaButtonProps,
+  TooltipTrigger,
+} from "react-aria-components";
+import { Tooltip } from "../Tooltip";
 
 const buttonVariants = cva(styles.button, {
   variants: {
@@ -27,7 +31,7 @@ const buttonVariants = cva(styles.button, {
 });
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends ReactAriaButtonProps,
     VariantProps<typeof buttonVariants> {
   icon?: LucideIcon;
   tooltip?: React.ReactNode;
@@ -48,26 +52,22 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref,
   ) => {
     const buttonClassNames = buttonVariants({ variant, size, className });
-    const buttonContent = (
-      <>
-        {Icon && <Icon className={styles.icon} />}
-        {children}
-      </>
+    const button = (
+      <ReactAriaButton className={buttonClassNames} {...props} ref={ref}>
+        <>
+          {Icon && <Icon className={styles.icon} />}
+          {children}
+        </>
+      </ReactAriaButton>
     );
     if (tooltip) {
       return (
-        <Tooltip>
-          <TooltipTrigger className={buttonClassNames} {...props} ref={ref}>
-            {buttonContent}
-          </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
-        </Tooltip>
+        <TooltipTrigger delay={0}>
+          {button}
+          <Tooltip>{tooltip}</Tooltip>
+        </TooltipTrigger>
       );
     }
-    return (
-      <HeadlessButton className={buttonClassNames} {...props} ref={ref}>
-        {buttonContent}
-      </HeadlessButton>
-    );
-  },
+    return button;
+  }
 );

--- a/src/renderer/ui/EnhanceButton/EnhanceButton.stories.ts
+++ b/src/renderer/ui/EnhanceButton/EnhanceButton.stories.ts
@@ -15,7 +15,7 @@ const meta: Meta<typeof EnhanceButton> = {
   tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-  args: { onClick: fn(), children: "Enhance", size: "default" },
+  args: { onPress: fn(), children: "Enhance", size: "default" },
   argTypes: {
     size: {
       control: { type: "select" },

--- a/src/renderer/ui/EnhanceButton/EnhanceButton.tsx
+++ b/src/renderer/ui/EnhanceButton/EnhanceButton.tsx
@@ -1,9 +1,10 @@
 import { Sparkles } from "lucide-react";
 import { forwardRef } from "react";
 import { Button, ButtonProps } from "../Button";
+import { ButtonProps as ReactAriaButtonProps } from "react-aria-components";
 
 export interface EnhanceButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends ReactAriaButtonProps{
   size?: ButtonProps["size"];
   tooltip?: React.ReactNode;
 }
@@ -18,9 +19,7 @@ export const EnhanceButton = forwardRef<HTMLButtonElement, EnhanceButtonProps>(
         tooltip={tooltip}
         {...props}
         ref={ref}
-      >
-        {props.children}
-      </Button>
+        />
     );
   },
 );

--- a/src/renderer/ui/IconButton/IconButton.stories.ts
+++ b/src/renderer/ui/IconButton/IconButton.stories.ts
@@ -16,7 +16,7 @@ const meta: Meta<typeof IconButton> = {
   tags: ["autodocs"],
   // More on argTypes: https://storybook.js.org/docs/api/argtypes
   // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
-  args: { onClick: fn(), size: "default", icon: Sparkles },
+  args: { onPress: fn(), size: "default", icon: Sparkles },
   argTypes: {
     variant: {
       control: { type: "select" },

--- a/src/renderer/ui/IconButton/IconButton.tsx
+++ b/src/renderer/ui/IconButton/IconButton.tsx
@@ -2,8 +2,12 @@ import { cva, type VariantProps } from "class-variance-authority";
 import styles from "./IconButton.module.css";
 import { LucideIcon } from "lucide-react";
 import { forwardRef } from "react";
-import { Button as HeadlessButton } from "@headlessui/react";
-import { Tooltip, TooltipTrigger, TooltipContent } from "../Tooltip";
+import {
+  Button as ReactAriaButton,
+  ButtonProps as ReactAriaButtonProps,
+  TooltipTrigger,
+} from "react-aria-components";
+import { Tooltip } from "../Tooltip";
 
 const iconButtonVariants = cva(styles.iconButton, {
   variants: {
@@ -27,7 +31,7 @@ const iconButtonVariants = cva(styles.iconButton, {
 });
 
 export interface IconButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends ReactAriaButtonProps,
     VariantProps<typeof iconButtonVariants> {
   icon: LucideIcon;
   tooltip?: React.ReactNode;
@@ -45,25 +49,21 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       className,
     });
 
-    const iconContent = (
-        <Icon className={styles.icon} />
+    const iconButton = (
+      <ReactAriaButton className={iconButtonClassNames} {...props} ref={ref}>
+        {<Icon className={styles.icon} />}
+      </ReactAriaButton>
     );
 
     if (tooltip) {
       return (
-        <Tooltip>
-          <TooltipTrigger className={iconButtonClassNames} {...props} ref={ref}>
-            {iconContent}
-          </TooltipTrigger>
-          <TooltipContent>{tooltip}</TooltipContent>
-        </Tooltip>
+        <TooltipTrigger delay={0}>
+          {iconButton}
+          <Tooltip>{tooltip}</Tooltip>
+        </TooltipTrigger>
       );
     }
 
-    return (
-      <HeadlessButton className={iconButtonClassNames} ref={ref} {...props}>
-        {iconContent}
-      </HeadlessButton>
-    );
+    return iconButton;
   },
 );

--- a/src/renderer/ui/Tooltip/Tooltip.tsx
+++ b/src/renderer/ui/Tooltip/Tooltip.tsx
@@ -1,168 +1,19 @@
-// gotten from https://floating-ui.com/docs/tooltip
-import * as React from "react";
-import { Button as HeadlessButton } from "@headlessui/react";
-import {
-  useFloating,
-  autoUpdate,
-  offset,
-  flip,
-  shift,
-  useHover,
-  useFocus,
-  useDismiss,
-  useRole,
-  useInteractions,
-  useMergeRefs,
-  FloatingPortal
-} from "@floating-ui/react";
-import type { Placement } from "@floating-ui/react";
+import { cx } from "class-variance-authority";
+import type {TooltipProps as ReactAriaTooltipProps} from "react-aria-components"
+import { Tooltip as ReactAriaTooltip } from "react-aria-components"
+
 import styles from "./Tooltip.module.css";
 
-interface TooltipOptions {
-  initialOpen?: boolean;
-  placement?: Placement;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+
+export interface TooltipProps extends Omit<ReactAriaTooltipProps, "children"> {
+  children: React.ReactNode;
 }
 
-export function useTooltip({
-  initialOpen = false,
-  placement = "top",
-  open: controlledOpen,
-  onOpenChange: setControlledOpen
-}: TooltipOptions = {}) {
-  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(initialOpen);
-
-  const open = controlledOpen ?? uncontrolledOpen;
-  const setOpen = setControlledOpen ?? setUncontrolledOpen;
-
-  const data = useFloating({
-    placement,
-    open,
-    onOpenChange: setOpen,
-    whileElementsMounted: autoUpdate,
-    middleware: [
-      offset(6),
-      flip({
-        crossAxis: placement.includes("-"),
-        fallbackAxisSideDirection: "start",
-        padding: 6
-      }),
-      shift({ padding: 6 })
-    ]
-  });
-
-  const context = data.context;
-
-  const hover = useHover(context, {
-    move: false,
-    enabled: controlledOpen == null
-  });
-  const focus = useFocus(context, {
-    enabled: controlledOpen == null
-  });
-  const dismiss = useDismiss(context);
-  const role = useRole(context, { role: "tooltip" });
-
-  const interactions = useInteractions([hover, focus, dismiss, role]);
-
-  return React.useMemo(
-    () => ({
-      open,
-      setOpen,
-      ...interactions,
-      ...data
-    }),
-    [open, setOpen, interactions, data]
+export const Tooltip = ({ children, className, ...props }: TooltipProps) => {
+  const tooltipClassNames = cx(styles.tooltip, className);
+  return (
+    <ReactAriaTooltip className={tooltipClassNames} offset={props.offset ?? 5} {...props}>
+      {children}
+    </ReactAriaTooltip>
   );
-}
-
-type ContextType = ReturnType<typeof useTooltip> | null;
-
-const TooltipContext = React.createContext<ContextType>(null);
-
-export const useTooltipContext = () => {
-  const context = React.useContext(TooltipContext);
-
-  if (context == null) {
-    throw new Error("Tooltip components must be wrapped in <Tooltip />");
-  }
-
-  return context;
 };
-
-export function Tooltip({
-  children,
-  ...options
-}: { children: React.ReactNode } & TooltipOptions) {
-  // This can accept any props as options, e.g. `placement`,
-  // or other positioning options.
-  const tooltip = useTooltip(options);
-  return (
-    <TooltipContext.Provider value={tooltip}>
-      {children}
-    </TooltipContext.Provider>
-  );
-}
-
-export const TooltipTrigger = React.forwardRef<
-  HTMLElement,
-  React.HTMLProps<HTMLElement> & { asChild?: boolean }
->(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
-  const context = useTooltipContext();
-  // think about this
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const childrenRef = (children as any).ref;
-  const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef]);
-
-  // `asChild` allows the user to pass any element as the anchor
-  if (asChild && React.isValidElement(children)) {
-    const dataAttributes = {
-      "data-tooltip-state": context.open ? "open" : "closed",
-    }
-    return React.cloneElement(
-      children,
-      context.getReferenceProps({
-        ref,
-        ...props,
-        ...(typeof children.props === "object" ? children.props : {}),
-        ...dataAttributes,
-      })
-    );
-  }
-
-  return (
-    <HeadlessButton
-      ref={ref}
-      // The user can style the trigger based on the state
-      data-tooltip-state={context.open ? "open" : "closed"}
-      {...context.getReferenceProps(props)}
-    >
-      {children}
-    </HeadlessButton>
-  );
-});
-
-export const TooltipContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLProps<HTMLDivElement>
->(function TooltipContent({ style, ...props }, propRef) {
-  const context = useTooltipContext();
-  const ref = useMergeRefs([context.refs.setFloating, propRef]);
-
-  if (!context.open) return null;
-
-  return (
-    <FloatingPortal>
-      <div
-        className={styles.tooltip}
-        ref={ref}
-        style={{
-          ...context.floatingStyles,
-          ...style
-        }}
-        {...context.getFloatingProps(props)}
-      />
-    </FloatingPortal>
-  );
-});


### PR DESCRIPTION
The purpose of this PR is to migrate to the `react-aria-components` library for all headless UI components. This includes Tooltip components and the already implemented Button components